### PR TITLE
HFP-3825 Add guard against crazy ;-) content types

### DIFF
--- a/src/scripts/models/exercise.js
+++ b/src/scripts/models/exercise.js
@@ -275,6 +275,10 @@ export default class Exercise {
       return; // Not relevant
     }
 
+    if (!this.extendsH5PQuestion && !this.continueButton) {
+      return; // Guard to make robust against content types firing xAPI events when not attached
+    }
+
     const isCompletedEnough =
       this.params.globals.get('params').behaviour.map.roaming !== 'success';
 


### PR DESCRIPTION
When merged in, will add a guard against content types that may fire xAPI relevant for scoring without being attached to a Game Map exercise popup.